### PR TITLE
AG-125: fixing build issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Imports:
     assertr,
     magrittr
 Additional_repositories:
-  https://sage-bionetworks.github.io/ran
+   http://ran.synapse.org,
+   http://cran.fhcrc.org
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get install -y dpkg-dev zlib1g-dev libssl-dev libffi-dev
 RUN apt-get install -y curl libcurl4-openssl-dev
 
 ENV R_REMOTES_NO_ERRORS_FROM_WARNINGS=true
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=true
 
 COPY . /agoradataprocessing
 WORKDIR /agoradataprocessing


### PR DESCRIPTION
## What's Inside

This fixes the problems described in [AG-125](https://sagebionetworks.jira.com/browse/AG-125).  In summary, the location the R package for synapse resides needed to be updated + addressing an issue that prevents synapser to be installed.